### PR TITLE
Move Position, Size, ... structs to a separate file

### DIFF
--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES src/main.cpp
             src/Client.cpp
             src/context/Resources.cpp
             src/controller/HomeController.cpp
+            src/view/ComponentParams.cpp
             src/view/BaseComponent.cpp
             src/view/BaseView.cpp
             src/view/home/HomeView.cpp
@@ -30,6 +31,7 @@ set(HEADERS memo/Client.hpp
             src/context/Resources.hpp
             src/controller/HomeController.hpp
             src/controller/IController.hpp
+            src/view/ComponentParams.hpp
             src/view/IComponent.hpp
             src/view/BaseComponent.hpp
             src/view/IView.hpp

--- a/src/view/BaseComponent.cpp
+++ b/src/view/BaseComponent.cpp
@@ -4,11 +4,11 @@ namespace memo {
 namespace ui {
 
 BaseComponent::BaseComponent() :
-    BaseComponent({ 0, 0 }, { 0, 0 })
+    BaseComponent(Size(), Position())
 {}
 
 BaseComponent::BaseComponent(const Size& iSize) :
-    BaseComponent(iSize, { 0, 0 })
+    BaseComponent(iSize, Position())
 {}
 
 BaseComponent::BaseComponent(const Size& iSize, const Position& iPosition) :

--- a/src/view/BaseView.cpp
+++ b/src/view/BaseView.cpp
@@ -53,11 +53,13 @@ const Border BORDER_DEFAULT {
 };
 
 BaseView::BaseView(IView* iParent) :
-    BaseView({ LINES, COLS }, { 0, 0 }, iParent)
+    BaseView( Size(Height(LINES), Width(COLS)),
+              Position(),
+              iParent )
 {}
 
 BaseView::BaseView(const Size& iSize, IView* iParent) :
-    BaseView(iSize, { 0, 0 }, iParent)
+    BaseView(iSize, Position(), iParent)
 {}
 
 BaseView::BaseView(const Size& iSize, const Position& iPosition, IView* iParent) :
@@ -123,7 +125,7 @@ Size BaseView::getParentSize() const
 Position BaseView::getParentPosition() const
 {
     if (parentView_) return parentView_->getPosition();
-    return { 0, 0 };
+    return Position(); // return 0, 0 coordinates
 }
 
 void BaseView::eraseWindow()
@@ -184,7 +186,7 @@ int BaseView::getWidth() const
 
 Size BaseView::getSize() const
 {
-    return { height_, width_ };
+    return { Height(height_), Width(width_) };
 }
 
 void BaseView::setY(int iY)

--- a/src/view/ComponentParams.cpp
+++ b/src/view/ComponentParams.cpp
@@ -1,0 +1,43 @@
+#include "view/ComponentParams.hpp"
+
+namespace memo {
+namespace ui {
+
+Rows::Rows(int iValue) : value(iValue)
+{
+}
+
+Cols::Cols(int iValue) : value(iValue)
+{
+}
+
+PosY::PosY(int iValue) : value(iValue)
+{
+}
+
+PosX::PosX(int iValue) : value(iValue)
+{
+}
+
+Size::Size() : height(0), width(0)
+{
+}
+
+Size::Size(Height iHeight, Width iWidth) :
+    height(iHeight.value),
+    width(iWidth.value)
+{
+}
+
+Position::Position() : x(0), y(0)
+{
+}
+
+Position::Position(PosX iX, PosY iY) :
+    x(iX.value),
+    y(iY.value)
+{
+}
+
+} // namespace ui
+} // namespace memo

--- a/src/view/ComponentParams.hpp
+++ b/src/view/ComponentParams.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+namespace memo {
+namespace ui {
+
+struct Rows
+{
+    explicit Rows(int iValue);
+
+    int value;
+};
+
+using Height = Rows;
+
+struct Cols
+{
+    explicit Cols(int iValue);
+
+    int value;
+};
+
+using Width = Cols;
+
+struct PosX
+{
+    explicit PosX(int iValue);
+
+    int value;
+};
+
+struct PosY
+{
+    explicit PosY(int iValue);
+
+    int value;
+};
+
+struct Size
+{
+    Size();
+    Size(Height iHeight, Width iWidth);
+
+    int height, width;
+};
+
+struct Position
+{
+    Position();
+    Position(PosX iX, PosY iY);
+
+    int x, y;
+};
+
+} // namespace ui
+} // namespace memo

--- a/src/view/IComponent.hpp
+++ b/src/view/IComponent.hpp
@@ -1,17 +1,8 @@
 #pragma once
+#include "view/ComponentParams.hpp"
 
 namespace memo {
 namespace ui {
-
-struct Size
-{
-    int height, width;
-};
-
-struct Position
-{
-    int y, x;
-};
 
 class IComponent
 {

--- a/src/view/home/HomeView.cpp
+++ b/src/view/home/HomeView.cpp
@@ -132,11 +132,14 @@ const std::vector<MenuItem> HomeView::kMenuItems {
 };
 
 HomeView::HomeView(IView* iParent) :
-    HomeView({ LINES, COLS }, { 0, 0 }, iParent)
-{}
+    HomeView( Size(Height(LINES), Width(COLS)),
+              Position(),
+              iParent )
+{
+}
 
 HomeView::HomeView(const Size& iSize, IView* iParent) :
-    HomeView(iSize, { 0, 0 }, iParent)
+    HomeView(iSize, Position(), iParent)
 {}
 
 HomeView::HomeView(const Size& iSize, const Position& iPosition, IView* iParent) :

--- a/src/view/home/MenuView.cpp
+++ b/src/view/home/MenuView.cpp
@@ -14,19 +14,19 @@ const std::vector<std::string> MenuView::kMenuItemNames {
 };
 
 MenuView::MenuView(IView* iParent) :
-    MenuView({ 0, 0 }, { 0, 0 }, iParent)
+    MenuView(Size(), Position(), iParent)
 {}
 
 MenuView::MenuView(const Size& iSize, IView* iParent) :
-    MenuView(iSize, { 0, 0 }, iParent)
+    MenuView(iSize, Position(), iParent)
 {}
 
 MenuView::MenuView(const Size& iSize, const Position& iPosition, IView* iParent) :
     BaseView(iSize, iPosition, iParent),
     menuWindow_(derwin(&getWindow(), 0, 0, 1, 1)),
     menu_(new_menu(nullptr)),
-    menuWindowSize_({ 0, 0 }),
-    menuWindowPos_({ 0, 0 }),
+    menuWindowSize_(Size()),
+    menuWindowPos_(Position()),
     menuWindowLayout_(Rows(0), Cols(0)),
     selectionMark_(""),
     menuItemsChanged_(false)
@@ -201,6 +201,22 @@ void MenuView::applyMenuChanges()
 
     post_menu(menu_.get());
 }
+
+MenuView::Layout::Layout(Rows iRows, Cols iCols) :
+    rows(iRows.value), cols(iCols.value)
+{
+}
+
+bool MenuView::Layout::operator==(const Layout& other)
+{
+    return rows == other.rows && cols == other.cols;
+}
+
+bool MenuView::Layout::operator!=(const Layout& other)
+{
+    return rows != other.rows || cols != other.cols;
+}
+
 
 } // namespace ui
 } // namespace memo

--- a/src/view/home/MenuView.hpp
+++ b/src/view/home/MenuView.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "view/BaseView.hpp"
 #include "view/home/MenuItem.hpp"
+#include "view/ComponentParams.hpp"
 
 #include <string>
 #include <vector>
@@ -12,39 +13,18 @@ struct tagMENU;
 namespace memo {
 namespace ui {
 
-struct Rows
-{
-    explicit Rows(int iValue) : value(iValue) {}
-
-    int value;
-};
-
-struct Cols
-{
-    explicit Cols(int iValue) : value(iValue) {}
-
-    int value;
-};
-
 class MenuView : public BaseView
 {
     static const int MENU_ITEM_COUNT = 6;
     static const std::vector<std::string> kMenuItemNames;
 
-    struct Layout
+    class Layout
     {
-        Layout(Rows iRows, Cols iCols) :
-            rows(iRows.value), cols(iCols.value) {}
+    public:
+        Layout(Rows iRows, Cols iCols);
 
-        bool operator==(const Layout& other)
-        {
-            return rows == other.rows && cols == other.cols;
-        }
-
-        bool operator!=(const Layout& other)
-        {
-            return rows != other.rows || cols != other.cols;
-        }
+        bool operator==(const Layout& other);
+        bool operator!=(const Layout& other);
 
         int rows;
         int cols;

--- a/src/view/widget/Text.cpp
+++ b/src/view/widget/Text.cpp
@@ -9,11 +9,11 @@ namespace {
 } // namespace
 
 Text::Text() :
-    Text("", { 0, 0 })
+    Text("", Position())
 {}
 
 Text::Text(const std::string& iText) :
-    Text(iText, { 0, 0 })
+    Text(iText, Position())
 {}
 
 Text::Text(const std::string& iText, const Position& iPosition) :


### PR DESCRIPTION
Define new file(s) ComponentParams.[h/c]pp where Position, Size, Rows, Cols, PosX, PosY struts are defined. These have been scattered in various other files, this way they are in one accessible place. 

Also update Components and Views with the new constructor initialisation of Position and Size.