### PR TITLE
Remove dependency of builds on Linux container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ compile_flags.txt
 # VIM
 *.swp
 
+# Qt creator
+*.cflags
+*.config
+*.creator
+*.user
+*.cxxflags
+*.files
+*.includes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required (VERSION 3.0)
 
 project (Memo-server LANGUAGES CXX)
-add_compile_options(-std=c++17 -g -fstandalone-debug -Wall -Wextra -Wsign-conversion)
+add_compile_options(-std=c++17 -g -Wall -Wextra -Wsign-conversion)
 
-set(CMAKE_CXX_COMPILER /usr/bin/clang++)
 # Use the "gold-linker" to speed-up the linking phase
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
+if (UNIX AND NOT APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
+endif()
 
 # variable denoting where the "absolute" include paths start in
 set(BASEPATH "${CMAKE_SOURCE_DIR}/src/")
@@ -149,7 +150,9 @@ target_link_libraries(memo_client_cli
     ${_REFLECTION}
     ${_GRPC_GRPCPP}
     ${_PROTOBUF_LIBPROTOBUF})
-target_link_libraries(memo_client_cli ncurses)
+find_package(Curses REQUIRED)
+target_include_directories(memo_client_cli PRIVATE ${CURSES_DIRECTORIES})
+target_link_libraries(memo_client_cli ${CURSES_LIBRARIES})
 target_link_libraries(memo_client_cli menu)
 # needed for "absolute" include paths
 target_include_directories(memo_client_cli PRIVATE ${BASEPATH})

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 #include <grpcpp/grpcpp.h>
-#include <ncursesw/curses.h>
+#include <curses.h>
 
 namespace memo {
 

--- a/src/controller/HomeController.cpp
+++ b/src/controller/HomeController.cpp
@@ -2,7 +2,7 @@
 #include "view/home/HomeView.hpp"
 #include "view/home/MenuView.hpp"
 #include "manager/ControllerManager.hpp"
-#include <ncursesw/menu.h>
+#include <menu.h>
 
 namespace memo {
 namespace ctrl {

--- a/src/view/BaseView.cpp
+++ b/src/view/BaseView.cpp
@@ -42,7 +42,7 @@ void BaseView::println(const std::string& iContent) const
 } // namespace memo
 
 #include "view/widget/Text.hpp"
-#include <ncursesw/curses.h>
+#include <curses.h>
 
 namespace memo {
 namespace ui {
@@ -76,8 +76,7 @@ BaseView::~BaseView()
     if (window_)
     {
         eraseWindow();
-        auto* window = window_.release();
-        delwin(window);
+        delwin(window_);
     }
 }
 
@@ -94,15 +93,15 @@ void BaseView::refresh()
     const int x = parentPos.x + x_;
 
     beforeViewResized();
-    wresize(window_.get(), height_, width_);
-    mvwin(window_.get(), y, x);
+    wresize(window_, height_, width_);
+    mvwin(window_, y, x);
 
     positionComponents(*window_);
     displayContent(*window_);
 
-    box(window_.get(), border_.left, border_.top);
+    box(window_, border_.left, border_.top);
 
-    wrefresh(window_.get());
+    wrefresh(window_);
 
     for (const auto& subView : subViews_)
     {
@@ -131,15 +130,15 @@ Position BaseView::getParentPosition() const
 void BaseView::eraseWindow()
 {
     if (!window_) return;
-    wborder(window_.get(), ' ', ' ', ' ',' ',' ',' ',' ',' ');
-    wrefresh(window_.get());
+    wborder(window_, ' ', ' ', ' ',' ',' ',' ',' ',' ');
+    wrefresh(window_);
     applyBorder();
 }
 
 void BaseView::applyBorder()
 {
     if (!window_) return;
-    wborder(window_.get(),
+    wborder(window_,
             border_.left, border_.right,
             border_.top, border_.bottom,
             border_.corner.upperLeft,
@@ -246,7 +245,7 @@ Border BaseView::getBorder() const
 
 void BaseView::displayText(const widget::Text& iText)
 {
-    mvwprintw(window_.get(), iText.getY(), iText.getX(), iText.getText().c_str());
+    mvwprintw(window_, iText.getY(), iText.getX(), iText.getText().c_str());
 }
 
 Window_t& BaseView::getWindow()

--- a/src/view/BaseView.hpp
+++ b/src/view/BaseView.hpp
@@ -34,7 +34,7 @@ private:
 
 struct _win_st;
 
-using WindowPtr_t = std::unique_ptr<Window_t>;
+using WindowPtr_t = Window_t*;
 
 namespace memo {
 namespace ui {

--- a/src/view/ComponentParams.cpp
+++ b/src/view/ComponentParams.cpp
@@ -29,6 +29,16 @@ Size::Size(Height iHeight, Width iWidth) :
 {
 }
 
+bool Size::operator==(const Size& iOther)
+{
+    return width == iOther.width && height == iOther.height;
+}
+
+bool Size::operator!=(const Size& iOther)
+{
+    return width != iOther.width && height != iOther.height;
+}
+
 Position::Position() : x(0), y(0)
 {
 }
@@ -37,6 +47,16 @@ Position::Position(PosX iX, PosY iY) :
     x(iX.value),
     y(iY.value)
 {
+}
+
+bool Position::operator==(const Position& iOther)
+{
+    return x == iOther.x && y == iOther.y;
+}
+
+bool Position::operator!=(const Position& iOther)
+{
+    return x != iOther.x && y != iOther.y;
 }
 
 } // namespace ui

--- a/src/view/ComponentParams.hpp
+++ b/src/view/ComponentParams.hpp
@@ -40,6 +40,9 @@ struct Size
     Size();
     Size(Height iHeight, Width iWidth);
 
+    bool operator==(const Size& iOther);
+    bool operator!=(const Size& iOther);
+
     int height, width;
 };
 
@@ -47,6 +50,9 @@ struct Position
 {
     Position();
     Position(PosX iX, PosY iY);
+
+    bool operator==(const Position& iOther);
+    bool operator!=(const Position& iOther);
 
     int x, y;
 };

--- a/src/view/home/HomeView.cpp
+++ b/src/view/home/HomeView.cpp
@@ -111,7 +111,7 @@ void HomeView::handleInvalidOption()
 #include "view/widget/Text.hpp"
 #include "view/tools/Tools.hpp"
 
-#include <ncursesw/menu.h>
+#include <menu.h>
 
 namespace memo {
 namespace ui {

--- a/src/view/home/MenuView.hpp
+++ b/src/view/home/MenuView.hpp
@@ -69,7 +69,9 @@ private:
     WindowPtr_t menuWindow_;
     std::unique_ptr<tagMENU> menu_;
 
+    Size oldMenuWindowSize_;
     Size menuWindowSize_;
+    Position oldMenuWindowPos_;
     Position menuWindowPos_;
     Layout menuWindowLayout_;
     std::string selectionMark_;


### PR DESCRIPTION
Executing cmake (CMakeLists.txt) and building the executable were to a
certain extent dependent on being run in Docker container
preconfigured with Ubuntu distro of Linux. Project compilation failed
on OSs other than Linux, which posed a problem when one needed to debug
the built executable on their native platform.