### PR TITLE
Replace curses' WINDOW with wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ compile_flags.txt
 
 #Mac
 .DS_Store
+
+#VS Code
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required (VERSION 3.0)
 
 project (Memo-server LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-std=c++17 -g -Wall -Wextra -Wsign-conversion)
 
 # Use the "gold-linker" to speed-up the linking phase
@@ -26,6 +27,7 @@ list(APPEND PROTO_FILES ${PROTO_SVC_FILES})
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
 
 # OpenSSL
 if (APPLE)
@@ -121,11 +123,29 @@ target_link_libraries(memo_client_cli
     ${_GRPC_GRPCPP}
     ${_PROTOBUF_LIBPROTOBUF})
 
-find_package(Curses REQUIRED)
-target_include_directories(memo_client_cli PRIVATE ${CURSES_INCLUDE_DIRS})
-target_link_libraries(memo_client_cli ncurses)
-find_library(MENU_LIB menu REQUIRED)
-target_link_libraries(memo_client_cli ${MENU_LIB})
+# Link ncurses libs
+set(CURSES_NEED_NCURSES TRUE)
+set(curses_lib_dir)
+set(curses_include_dir)
+if (CURSES_DIR)
+    message("Searching for ncurses in: " ${CURSES_DIR})
+    find_library(NCURSES_LIB ncurses PATHS ${CURSES_DIR}/lib REQUIRED)
+    find_library(MENU_LIB menu PATHS ${CURSES_DIR}/lib REQUIRED)
+    set(curses_lib_dir ${CURSES_DIR}/lib)
+    set(curses_include_dir ${CURSES_DIR}/include)
+else()
+    find_package(Curses REQUIRED)
+    find_library(menu_lib menu REQUIRED)
+    get_filename_component(curses_lib_dir ${menu_lib} DIRECTORY)
+    get_filename_component(curses_dir ${curses_lib_dir} DIRECTORY)
+    set(curses_include_dir ${curses_lib_dir}/include)
+endif()
+
+message("Linked ncurses library directory: " ${curses_lib_dir})
+message("Ncurses include directory: " ${curses_include_dir})
+target_include_directories(memo_client_cli PRIVATE ${curses_include_dir})
+target_link_directories(memo_client_cli PRIVATE ${curses_lib_dir})
+target_link_libraries(memo_client_cli ncurses menu)
 
 # needed for "absolute" include paths
 target_include_directories(memo_client_cli PRIVATE ${BASEPATH})

--- a/scripts/setup
+++ b/scripts/setup
@@ -27,7 +27,7 @@ rm -rf $BUILD_DIR/*
 
 cd $BUILD_DIR
 echo $(pwd)
-cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_PREFIX_PATH=~/.local/ ..
+cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
 exit_on_fail
 
 cd $PROJECT_DIR_PATH

--- a/src/controller/HomeController.cpp
+++ b/src/controller/HomeController.cpp
@@ -2,12 +2,12 @@
 #include "view/home/HomeView.hpp"
 #include "view/home/MenuView.hpp"
 #include "manager/ControllerManager.hpp"
-#include <menu.h>
+
+#include "ncurses/functions.hpp"
+#include "ncurses/keys.hpp"
 
 namespace memo {
 namespace ctrl {
-
-const unsigned int kKeyEnter = 10;
 
 HomeController::HomeController(const ResourcesPtr_t& iResources) :
     BaseController(iResources)
@@ -18,33 +18,40 @@ HomeController::HomeController(const ResourcesPtr_t& iResources) :
 
 void HomeController::processInput()
 {
-    auto& cursesWindow = view()->getWindow();
-    keypad(&cursesWindow, TRUE);
-    int input = wgetch(&cursesWindow);
+    auto& cursesWindow = view()->getMenuView()->getWindow();
 
-    switch (input)
+    curses::KeyPad(cursesWindow, ENABLE);
+    const int input = curses::ReadChar(cursesWindow);
+    if (input == curses::Key::kDown)
     {
-        case KEY_DOWN:
-            view()->getMenuView()->navigateMenuDown();
-            break;
-        case KEY_UP:
-            view()->getMenuView()->navigateMenuUp();
-            break;
-        case KEY_LEFT:
-            view()->getMenuView()->navigateMenuLeft();
-            break;
-        case KEY_RIGHT:
-            view()->getMenuView()->navigateMenuRight();
-            break;
-        case kKeyEnter:
-        {
-            const auto& selection = view()->getMenuView()->getSelected();
-            onMenuOptionSelected(selection);
-        } break;
-        default:
-            view()->setErrorStatus("Unprocessed Key code: " + std::to_string(input));
+        view()->getMenuView()->navigateMenuDown();
     }
-    keypad(&cursesWindow, FALSE);
+    else if (input == curses::Key::kUp)
+    {
+        view()->getMenuView()->navigateMenuUp();
+    }
+    else if (input == curses::Key::kLeft)
+    {
+        view()->getMenuView()->navigateMenuLeft();
+    }
+    else if (input == curses::Key::kRight)
+    {
+        view()->getMenuView()->navigateMenuRight();
+    }
+    else if (input == curses::Key::kEnter)
+    {
+        const auto& selection = view()->getMenuView()->getSelected();
+        onMenuOptionSelected(selection);
+    }
+    else if (input == 'q')
+    {
+        getResources()->getControllerManager()->pop();
+    }
+    else
+    {
+        view()->setErrorStatus("Unprocessed Key code: " + std::to_string(input));
+    }
+    curses::KeyPad(DISABLE);
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,24 +2,19 @@
 
 #include <iostream>
 #include <thread>
+#include <locale>
 
 using memo::Client;
 
 int main(int argc, char** argv)
 {
-  	try
-  	{
-  	    if (argc != 3)
-  	    {
-  	      std::cerr << "Usage: http_server <address> <port>\n";
-  	      std::cerr << "Ex   : http_server 127.0.0.1 8000\n";
-  	      return 1;
-        }
-  	}
-  	catch (std::exception& e)
-  	{
-        std::cout << "exception:\n" << e.what() << std::endl;
-  	}
+    if (argc != 3)
+    {
+        std::cerr << "Usage: http_server <address> <port>\n";
+        std::cerr << "Ex   : http_server 127.0.0.1 8000\n";
+        return 1;
+    }
+    setlocale(LC_ALL, "");
 
     const std::string ipAddress = argv[1];
     const std::string port = argv[2];

--- a/src/ncurses/BaseWindow.cpp
+++ b/src/ncurses/BaseWindow.cpp
@@ -1,19 +1,15 @@
 #include "ncurses/BaseWindow.hpp"
+#include "ncurses/functions.hpp"
 
 #include <ncurses.h>
 
 namespace memo {
 namespace curses {
 
-const Border kDefaultBorder {
-    ACS_HLINE, ACS_VLINE, ACS_HLINE, ACS_VLINE,
-    { ACS_ULCORNER, ACS_URCORNER, ACS_LLCORNER, ACS_LLCORNER }
-};
-
 BaseWindow::BaseWindow(const Position& position, const Size& size) :
     position_(position),
     size_(size),
-    border_(kDefaultBorder)
+    border_(DefaultBorder())
 {
 }
 
@@ -49,6 +45,21 @@ BaseWindow& BaseWindow::operator=(BaseWindow&& other)
         border_ = other.border_;
     }
     return *this;
+}
+
+bool BaseWindow::redraw()
+{
+    int status = wborder(cursesWindow(), ' ', ' ', ' ',' ',' ',' ',' ',' ');
+    if (status != OK)
+        return false;
+
+    status = box(cursesWindow(), border_.left, border_.top);
+    if (status == OK)
+    {
+        status = wrefresh(cursesWindow());
+        setWindowBorder(border_);
+    }
+    return status == OK;
 }
 
 bool BaseWindow::setPosition(const Position& newPosition)
@@ -150,6 +161,11 @@ bool BaseWindow::setWindowBorder(const Border& newBorder)
 const Border& BaseWindow::windowBorder() const
 {
     return border_;
+}
+
+void BaseWindow::erase() const
+{
+    wborder(cursesWindow(), ' ', ' ', ' ',' ',' ',' ',' ',' ');
 }
 
 bool BaseWindow::deleteCursesWindow(_win_st*& window)

--- a/src/ncurses/BaseWindow.hpp
+++ b/src/ncurses/BaseWindow.hpp
@@ -25,6 +25,8 @@ public:
 
     virtual ~BaseWindow() = default;
 
+    virtual bool redraw() override;
+
     virtual bool setPosition(const Position& newPosition) override;
 
     virtual bool setX(const int newX) override;
@@ -54,6 +56,8 @@ public:
     virtual bool setWindowBorder(const Border& newBorder) override;
 
     virtual const Border& windowBorder() const override;
+
+    virtual void erase() const override;
 
 protected:
     bool deleteCursesWindow(_win_st*& window);

--- a/src/ncurses/IWindow.hpp
+++ b/src/ncurses/IWindow.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
-class _win_st;
+struct _win_st;
 
 namespace memo {
-    class Position;
-    class Size;
-    class Border;
+    struct Position;
+    struct Size;
+    struct Border;
 namespace curses {
-
-extern const Border kDefaultBorder;
 
 ///
 /// \brief An interface for a ncurses' WINDOW wrapper.
@@ -54,6 +52,8 @@ public:
     virtual bool setWindowBorder(const Border& newBorder) = 0;
 
     virtual const Border& windowBorder() const = 0;
+
+    virtual void erase() const = 0;
 
     ///
     /// \brief Get access to the underlying ncurses' WINDOW pointer.

--- a/src/ncurses/functions.cpp
+++ b/src/ncurses/functions.cpp
@@ -1,16 +1,11 @@
 #include "ncurses/functions.hpp"
+#include "ncurses/IWindow.hpp"
 #include "utils/Structs.hpp"
 
 #include <ncurses.h>
 
 namespace memo {
 namespace curses {
-
-class Window
-{
-public:
-    WINDOW* getCursesWindow() const { return nullptr; }
-};
 
 void InitCurses()
 {
@@ -55,29 +50,64 @@ void KeyPad(bool enable)
     keypad(stdscr, enabled);
 }
 
+void KeyPad(const IWindow& window, bool enable)
+{
+    int enabled = enable ? TRUE : FALSE;
+    keypad(window.cursesWindow(), enabled);
+}
+
 int ReadChar()
 {
     return getch();
 }
 
-int ReadChar(const Window& window)
+int ReadChar(const IWindow& window)
 {
-    return wgetch(window.getCursesWindow());
+    return wgetch(window.cursesWindow());
 }
 
-int ReadCharAt(const Position &position)
+int ReadCharAt(const Position& position)
 {
     return mvgetch(position.y, position.x);
 }
 
-int ReadCharAt(const Window &window, const Position &position)
+int ReadCharAt(const IWindow& window, const Position& position)
 {
-    return mvwgetch(window.getCursesWindow(), position.y, position.x);
+    return mvwgetch(window.cursesWindow(), position.y, position.x);
 }
 
+int ScreenWidth()
+{
+    return COLS;
+}
 
+int ScreenHeight()
+{
+    return LINES;
+}
 
+Size ScreenSize()
+{
+    return { Height(LINES), Width(COLS) };
+}
 
+int PrintText(const std::string& text, const Position& position)
+{
+    return mvprintw(position.y, position.x, text.c_str());
+}
+
+int PrintText(const std::string& text, const IWindow& window, const Position& position)
+{
+    return mvwprintw(window.cursesWindow(), position.y, position.x, text.c_str());
+}
+
+Border DefaultBorder()
+{
+    return {
+        ACS_HLINE, ACS_VLINE, ACS_HLINE, ACS_VLINE,
+        { ACS_ULCORNER, ACS_URCORNER, ACS_LLCORNER, ACS_LLCORNER }
+    };
+}
 
 } // namespace curses
 } // namespace memo

--- a/src/ncurses/functions.hpp
+++ b/src/ncurses/functions.hpp
@@ -1,15 +1,15 @@
 #pragma once
+#include "utils/Structs.hpp"
+#include <string>
 
 namespace memo {
-    class Position;
-
 
 const bool ENABLE = true;
 const bool DISABLE = false;
 
 namespace curses {
 
-    class Window;
+    class IWindow;
 
 ///
 /// \brief Initializes the main screen. Needs to be called before calling other
@@ -61,7 +61,7 @@ void KeyPad(bool enable);
 /// arrow keys, ...).
 /// \param enable True/false. Whether or not to enable special keys.
 ///
-void KeyPad(const Window& window, bool enable);
+void KeyPad(const IWindow& window, bool enable);
 
 ///
 /// \brief Reads the next input character typed by the user. The blocks the main thread
@@ -75,7 +75,7 @@ int ReadChar();
 /// operation blocks the main thread and waits for the user input.
 /// \return Integer representation of the read character.
 ///
-int ReadChar(const Window& window);
+int ReadChar(const IWindow& window);
 
 ///
 /// \brief Reads the next input character typed by the user from the specified position
@@ -91,7 +91,32 @@ int ReadCharAt(const Position& position);
 /// operation blocks the main thread and waits for the user input.
 /// \return Integer representation of the read character.
 ///
-int ReadCharAt(const Window& window, const Position& position);
+int ReadCharAt(const IWindow& window, const Position& position);
+
+///
+/// \brief Prints the given text at the specified position on the screen.
+/// \param text Text to print
+/// \param position Position on the screen.
+/// \return curses error code
+///
+int PrintText(const std::string& text, const Position& position);
+
+///
+/// \brief Prints the given text at the specified position in the window.
+/// \param text Text to print
+/// \param window Window on which to print
+/// \param position Position on the screen
+/// \return curses error code
+///
+int PrintText(const std::string& text, const IWindow& window, const Position& position);
+
+Size ScreenSize();
+
+int ScreenWidth();
+
+int ScreenHeight();
+
+Border DefaultBorder();
 
 }
 }

--- a/src/ncurses/keys.cpp
+++ b/src/ncurses/keys.cpp
@@ -1,0 +1,15 @@
+#include "keys.hpp"
+#include <ncurses.h>
+
+namespace memo {
+namespace curses {
+
+const int Key::kUp = KEY_UP;
+const int Key::kDown = KEY_DOWN;
+const int Key::kLeft = KEY_LEFT;
+const int Key::kRight = KEY_RIGHT;
+
+const int Key::kEnter = 10;
+
+} // namespace curses
+} // namespace memo

--- a/src/ncurses/keys.hpp
+++ b/src/ncurses/keys.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace memo {
+namespace curses {
+
+class Key
+{
+public:
+    static const int kUp;
+    static const int kDown;
+    static const int kLeft;
+    static const int kRight;
+
+    static const int kEnter;
+
+
+    Key() = delete;
+    Key(const Key&) = delete;
+    Key& operator=(const Key&) = delete;
+
+};
+
+} // namespace curses
+} // namespace memo

--- a/src/utils/Structs.cpp
+++ b/src/utils/Structs.cpp
@@ -28,12 +28,12 @@ Size::Size(Height iHeight, Width iWidth) :
 {
 }
 
-bool Size::operator==(const Size& iOther)
+bool Size::operator==(const Size& iOther) const
 {
     return width == iOther.width && height == iOther.height;
 }
 
-bool Size::operator!=(const Size& iOther)
+bool Size::operator!=(const Size& iOther) const
 {
     return width != iOther.width && height != iOther.height;
 }
@@ -48,12 +48,12 @@ Position::Position(PosX iX, PosY iY) :
 {
 }
 
-bool Position::operator==(const Position& iOther)
+bool Position::operator==(const Position& iOther) const
 {
     return x == iOther.x && y == iOther.y;
 }
 
-bool Position::operator!=(const Position& iOther)
+bool Position::operator!=(const Position& iOther) const
 {
     return x != iOther.x && y != iOther.y;
 }

--- a/src/utils/Structs.hpp
+++ b/src/utils/Structs.hpp
@@ -39,8 +39,8 @@ struct Size
     Size();
     Size(Height iHeight, Width iWidth);
 
-    bool operator==(const Size& iOther);
-    bool operator!=(const Size& iOther);
+    bool operator==(const Size& iOther) const;
+    bool operator!=(const Size& iOther) const;
 
     int height, width;
 };
@@ -50,8 +50,8 @@ struct Position
     Position();
     Position(PosX iX, PosY iY);
 
-    bool operator==(const Position& iOther);
-    bool operator!=(const Position& iOther);
+    bool operator==(const Position& iOther) const;
+    bool operator!=(const Position& iOther) const;
 
     int x, y;
 };
@@ -69,6 +69,5 @@ struct Border
     } corner;
 };
 
-extern const Border BORDER_DEFAULT;
 
 } // namespace memo

--- a/src/view/BaseView.hpp
+++ b/src/view/BaseView.hpp
@@ -32,10 +32,6 @@ private:
 
 #include <unordered_set>
 
-struct _win_st;
-
-using WindowPtr_t = Window_t*;
-
 namespace memo {
 namespace ui {
 namespace widget {
@@ -82,17 +78,17 @@ public:
     void setBorder(const Border& iBorder) override;
     Border getBorder() const override;
 
-    Window_t& getWindow() override;
+    curses::IWindow& getWindow() override;
+    void hideWindow();
 
 protected:
     virtual void beforeViewResized();
-    virtual void positionComponents(Window_t& ioWindow);
-    virtual void displayContent(Window_t& ioWindow);
+    virtual void positionComponents(curses::IWindow& ioWindow);
+    virtual void displayContent(curses::IWindow& ioWindow);
 
     void registerSubView(IView::Ptr iSubView);
     void removeSubView(IView::Ptr iSubView);
     void displayText(const widget::Text& iText);
-    void eraseWindow();
     Size getParentSize() const;
     Position getParentPosition() const;
 
@@ -101,12 +97,12 @@ private:
 
 private:
     IView* parentView_;
-    int width_, height_;
-    int x_, y_;
-    Border border_;
+    Position newPosition_;
+    Size newSize_;
+    Border newBorder_;
 
     bool visible_;
-    WindowPtr_t window_;
+    std::shared_ptr<curses::IWindow> window_;
     std::unordered_set<IView::Ptr> subViews_;
 };
 

--- a/src/view/IView.hpp
+++ b/src/view/IView.hpp
@@ -16,11 +16,10 @@ public:
 
 #include "view/IComponent.hpp"
 
-struct _win_st;
-
-using Window_t = _win_st;
-
 namespace memo {
+namespace curses {
+    class IWindow;
+} // namespace curses
 namespace ui {
 
 class IView : public IComponent
@@ -44,7 +43,7 @@ public:
     virtual void setBorder(const Border& iBorder) = 0;
     virtual Border getBorder() const = 0;
 
-    virtual Window_t& getWindow() = 0;
+    virtual curses::IWindow& getWindow() = 0;
 };
 
 } // namespace ui

--- a/src/view/home/HomeView.cpp
+++ b/src/view/home/HomeView.cpp
@@ -110,8 +110,7 @@ void HomeView::handleInvalidOption()
 #include "view/home/MenuView.hpp"
 #include "view/widget/Text.hpp"
 #include "view/tools/Tools.hpp"
-
-#include <menu.h>
+#include "ncurses/functions.hpp"
 
 namespace memo {
 namespace ui {
@@ -120,7 +119,6 @@ namespace ui {
 ///////////////////////////////////////////////////////////////
 /// HomeView
 ///////////////////////////////////////////////////////////////
-
 const std::vector<MenuItem> HomeView::kMenuItems {
     MenuItem(E_MenuItem::LIST_MEMOS,  "List Memos", ""),
     MenuItem(E_MenuItem::LIST_TAGS,   "List Tags", ""),
@@ -132,7 +130,7 @@ const std::vector<MenuItem> HomeView::kMenuItems {
 };
 
 HomeView::HomeView(IView* iParent) :
-    HomeView( Size(Height(LINES), Width(COLS)),
+    HomeView( curses::ScreenSize(),
               Position(),
               iParent )
 {
@@ -144,9 +142,9 @@ HomeView::HomeView(const Size& iSize, IView* iParent) :
 
 HomeView::HomeView(const Size& iSize, const Position& iPosition, IView* iParent) :
     BaseView(iSize, iPosition, iParent),
-    errorStatus_(new widget::Text("SOME TEXT")),
-    windowTitle_(new widget::Text("Welcome to the Memo-client-cli")),
-    menuView_(new MenuView)
+    errorStatus_(std::make_unique<widget::Text>("SOME TEXT")),
+    windowTitle_(std::make_unique<widget::Text>("Welcome to the Memo-client-cli")),
+    menuView_(std::make_shared<MenuView>())
 {
     registerSubView(menuView_);
     menuView_->setMenuItems(kMenuItems);
@@ -171,7 +169,7 @@ void HomeView::setErrorStatus(const std::string& iStatus)
     errorStatus_->setText(iStatus);
 }
 
-void HomeView::positionComponents(Window_t& ioWindow)
+void HomeView::positionComponents(curses::IWindow& ioWindow)
 {
     windowTitle_->setY(getY() + 2);
     errorStatus_->setY(getY() + getHeight() - 2);
@@ -186,7 +184,7 @@ void HomeView::positionComponents(Window_t& ioWindow)
                                   *this);
 }
 
-void HomeView::displayContent(Window_t& ioWindow)
+void HomeView::displayContent(curses::IWindow& ioWindow)
 {
     displayText(*windowTitle_);
     displayText(*errorStatus_);

--- a/src/view/home/HomeView.hpp
+++ b/src/view/home/HomeView.hpp
@@ -59,8 +59,8 @@ public:
     void setErrorStatus(const std::string& iStatus);
 
 protected:
-    void positionComponents(Window_t& ioWindow) override;
-    void displayContent(Window_t& ioWindow) override;
+    void positionComponents(curses::IWindow& ioWindow) override;
+    void displayContent(curses::IWindow& ioWindow) override;
 
 private:
     static const std::vector<MenuItem> kMenuItems;

--- a/src/view/home/MenuView.hpp
+++ b/src/view/home/MenuView.hpp
@@ -10,6 +10,9 @@ struct tagITEM;
 struct tagMENU;
 
 namespace memo {
+namespace curses {
+    class SubWindow;
+} // namespace curses
 namespace ui {
 
 class MenuView : public BaseView
@@ -22,8 +25,8 @@ class MenuView : public BaseView
     public:
         Layout(Rows iRows, Cols iCols);
 
-        bool operator==(const Layout& other);
-        bool operator!=(const Layout& other);
+        bool operator==(const Layout& other) const;
+        bool operator!=(const Layout& other) const;
 
         int rows;
         int cols;
@@ -50,8 +53,7 @@ public:
     void applyMenuChanges();
 
 protected:
-    void beforeViewResized() override;
-    void positionComponents(Window_t& ioWindow) override;
+    void positionComponents(curses::IWindow& ioWindow) override;
 
 private:
     void freeTagItems(std::vector<tagITEM*>& ioTagItems);
@@ -65,7 +67,7 @@ private:
 
     std::vector<MenuItem> menuItems_;
     std::vector<tagITEM*> tagItems_;
-    WindowPtr_t menuWindow_;
+    std::unique_ptr<curses::SubWindow> menuWindow_;
     std::unique_ptr<tagMENU> menu_;
 
     Size oldMenuWindowSize_;


### PR DESCRIPTION
Use the previously created wrapper classes to replace curses' WINDOW, adding an extra layer between the application and the ncurses library.